### PR TITLE
Dropped timeout for access logs to 2 seconds

### DIFF
--- a/tap_slack/streams/access_logs.py
+++ b/tap_slack/streams/access_logs.py
@@ -10,7 +10,7 @@ class AccessLogsStream(BaseStream):
     API_METHOD = 'team_accessLogs'
     TABLE = 'access_logs'
     KEY_PROPERTIES = ['user_id', 'ip', 'user_agent']
-    TIMEOUT = 3
+    TIMEOUT = 2
 
     def response_key(self):
         return 'logins'


### PR DESCRIPTION
Our access logs tap is no longer running due to the below error:
```
INFO  - Making request to team_accessLogs ({'count': 1000, 'page': 1, 'before': 'now'})
ERROR Failed to send a request to Slack API server: The read operation timed out
ERROR The read operation timed out
```

According to Slack docs, you need to respond within 3000ms. Honestly, I don't know if this solves it, but I'm willing to test? @drewbanin I don't mean to steal cycles from you, but if you immediately know how to solve this I'd be happy to implement :)