### PR TITLE
Fix: Drop result count per page from 1000 to 100 for access logs

### DIFF
--- a/tap_slack/streams/access_logs.py
+++ b/tap_slack/streams/access_logs.py
@@ -18,6 +18,8 @@ class AccessLogsStream(BaseStream):
     def get_params(self):
         return {
             "count": 100,
+            "page": 1,
+            "before": "now"
         }
 
     def transform_record(self, record):
@@ -35,11 +37,7 @@ class AccessLogsStream(BaseStream):
     def sync_paginated(self, params):
         table = self.TABLE
 
-        params = {
-            "count": 1000,
-            "page": 1,
-            "before": "now",
-        }
+        params = self.get_params()
 
         oldest, latest = self.get_lookback()
         stop_at_timestamp = oldest


### PR DESCRIPTION
Recently, we've been getting the below error for our Slack tap:
`ERROR Failed to send a request to Slack API server: The read operation timed out`

This PR drops the count of results per page from 1,000 down to 100 in hopes to reduce the time required to receive our requests. Ideally, this will resolve the time out errors. We shall test and see.